### PR TITLE
Make CE guns Biocodable

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -64,6 +64,9 @@
     <weaponTags>
       <li>Gun</li>
     </weaponTags>
+    <comps>
+      <li Class="CompProperties_Biocodable"/>
+    </comps>
   </ThingDef>
 
   <!-- ==================== Taurus Judge ==================== -->


### PR DESCRIPTION
CE guns can't spawn biocodable so I made a small change to make it possible.
Tested in-game with no errors and biocodable CE guns spawned like other normal guns.