### PR TITLE
Update Howitzer's Research Project

### DIFF
--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -41,7 +41,7 @@
     </placeWorkers>
     <size>(3,3)</size> 
     <researchPrerequisites>
-      <li>CE_HeavyTurret</li>
+      <li>CE_TurretHeavyWeapons</li>
       <li>Mortars</li>
     </researchPrerequisites>
     <minifiedDef>MinifiedThing</minifiedDef>


### PR DESCRIPTION
Changed the research project for unlocking the 105mm Howitzer to heavy weapons instead of heavy auto turrets.
A howitzer is not an auto-turret but a man operated artillery.