### PR TITLE
Make the Howitzer a proper mortar-type building

### DIFF
--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -80,7 +80,7 @@
         <defaultProjectile>Bullet_105mmHowitzerShell_HE</defaultProjectile>
         <warmupTime>4</warmupTime>
         <minRange>20</minRange>
-        <range>890</range>
+        <range>898</range>
 	<burstShotCount>1</burstShotCount>
         <soundCast>Mortar_LaunchA</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>

--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -6,6 +6,7 @@
     <defName>CE_Artillery_Howitzer</defName>
     <label>105mm howitzer</label>
     <description>A high caliber, relatively compact field artillery piece for indirect fire at extended ranges.</description>
+	<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
     <uiIconPath>Things/Howitzer/howitzer_uiIcon</uiIconPath>
     <uiIconScale>0.90</uiIconScale>
     <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
@@ -38,7 +39,7 @@
     <placeWorkers>
       <li>PlaceWorker_NotUnderRoof</li>
       <li>PlaceWorker_TurretTop</li>
-      <li>PlaceWorker_ShowTurretRadius</li>
+      <li>PlaceWorker_PreventInteractionSpotOverlap</li>
     </placeWorkers>
     <size>(3,3)</size>
     <fillPercent>0.85</fillPercent>
@@ -80,8 +81,8 @@
         <defaultProjectile>Bullet_105mmHowitzerShell_HE</defaultProjectile>
         <warmupTime>4</warmupTime>
         <minRange>20</minRange>
-        <range>898</range>
-	<burstShotCount>1</burstShotCount>
+        <range>900</range>
+		<burstShotCount>1</burstShotCount>
         <soundCast>Mortar_LaunchA</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>50</muzzleFlashScale>

--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -73,14 +73,14 @@
     </weaponTags>
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
-        <verbClass>CombatExtended.Verb_ShootCE</verbClass>
+        <verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
         <forceNormalTimeSpeed>false</forceNormalTimeSpeed>
         <hasStandardCommand>true</hasStandardCommand>
         <requireLineOfSight>false</requireLineOfSight>
         <defaultProjectile>Bullet_105mmHowitzerShell_HE</defaultProjectile>
         <warmupTime>4</warmupTime>
         <minRange>20</minRange>
-        <range>900</range>
+        <range>890</range>
 	<burstShotCount>1</burstShotCount>
         <soundCast>Mortar_LaunchA</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>

--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -6,7 +6,7 @@
     <defName>CE_Artillery_Howitzer</defName>
     <label>105mm howitzer</label>
     <description>A high caliber, relatively compact field artillery piece for indirect fire at extended ranges.</description>
-	<thingClass>CombatExtended.Building_TurretGunCE</thingClass>
+    <thingClass>CombatExtended.Building_TurretGunCE</thingClass>
     <uiIconPath>Things/Howitzer/howitzer_uiIcon</uiIconPath>
     <uiIconScale>0.90</uiIconScale>
     <constructionSkillPrerequisite>6</constructionSkillPrerequisite>
@@ -82,7 +82,7 @@
         <warmupTime>4</warmupTime>
         <minRange>20</minRange>
         <range>900</range>
-		<burstShotCount>1</burstShotCount>
+        <burstShotCount>1</burstShotCount>
         <soundCast>Mortar_LaunchA</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>50</muzzleFlashScale>


### PR DESCRIPTION
Fixed the verbClass of the Howitzer to the correct one used for mortars being "Verb_ShootMortarCE". it's an artillery gun not a manned turret