### PR TITLE
Remove the bipod from the SVD

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1046,7 +1046,6 @@
     </thingSetMakerTags>
     <weaponTags Inherit="False">
       <li>SniperRifle</li>
-      <li>Bipod_DMR</li>
       <li>CE_AI_SR</li>
     </weaponTags>
     <recipeMaker>


### PR DESCRIPTION
SVDs don't usually come with bipods and the in-game texture for them does not include one so, removed the tag to stay consistent to that and preserve the competition between the SVD and M24.