### PR TITLE
Night vision for charge sniper rifle

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1958,6 +1958,7 @@
       <Bulk>13.0</Bulk>
       <Mass>7.0</Mass>
       <RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+      <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
     </statBases>
     <costList>
       <Steel>70</Steel>


### PR DESCRIPTION
Gave the charge sniper rifle 0.4 base night vision capability to stay consistent with advanced man-made turrets and mechanoid turrets getting base NV.