### PR TITLE
RPG-7 rebalanced

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1679,7 +1679,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
-        <reloadTime>8.6</reloadTime>
+        <reloadTime>5.6</reloadTime>
         <ammoSet>AmmoSet_RPG7Grenade</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">


### PR DESCRIPTION
Adjusted RPG-7's reload time to a more realistic 5.6 seconds from 8.6s which brings it more in line with how the weapon is handled IRL while making the weapon more competitive in comparison to M72 LAWs.