### PR TITLE
AKS-74u to sub-carbine category

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -919,7 +919,7 @@
         <defaultProjectile>Bullet_545x39mmSoviet_FMJ</defaultProjectile>
         <burstShotCount>6</burstShotCount>
         <ticksBetweenBurstShots>6</ticksBetweenBurstShots>
-        <warmupTime>0.6</warmupTime>
+        <warmupTime>0.85</warmupTime>
         <range>40</range>
         <soundCast>Shot_AssaultRifle</soundCast>
         <soundCastTail>GunTail_Medium</soundCastTail>


### PR DESCRIPTION
Changed the AKS-74u to have a 0.85s warmup time, the "sub-carbine" warmup category which sits between rifles and SMGs with 1.1 and 0.6 warmup times respectively.