### PR TITLE
Add a reinforced barrel to the 105mm Howitzer's recipe

### DIFF
--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -22,6 +22,10 @@
       <Mass>1520</Mass>
       <Bulk>1000</Bulk>
     </statBases>
+    <costList>
+      <Steel>400</Steel>
+      <ComponentIndustrial>8</ComponentIndustrial>
+    </costList>
     <costListForDifficulty>
       <difficultyVar>classicMortars</difficultyVar>
       <invert>true</invert>

--- a/Defs/ThingDefs/Howitzer.xml
+++ b/Defs/ThingDefs/Howitzer.xml
@@ -22,10 +22,15 @@
       <Mass>1520</Mass>
       <Bulk>1000</Bulk>
     </statBases>
-    <costList>
-      <Steel>400</Steel>
-      <ComponentIndustrial>8</ComponentIndustrial>
-    </costList>
+    <costListForDifficulty>
+      <difficultyVar>classicMortars</difficultyVar>
+      <invert>true</invert>
+      <costList>
+        <ComponentIndustrial>8</ComponentIndustrial>
+        <ReinforcedBarrel>1</ReinforcedBarrel>
+      </costList>
+      <Steel>250</Steel>
+    </costListForDifficulty>
     <tradeTags>
       <li>CE_Turret</li>
     </tradeTags>


### PR DESCRIPTION
## Changes

- What it says on the tin

## Reasoning

- Added the reinforced barrel to the recipe just like how the vanilla mortar is set up for consistency's sake and reducing steel cost bloat.

## Testing

Check tests you have performed:
- [x] Game runs without errors
