### PR TITLE
move AK47 to GasOperation

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -657,7 +657,7 @@
       </li>
     </comps>
     <recipeMaker>
-      <researchPrerequisite>PrecisionRifling</researchPrerequisite>
+      <researchPrerequisite>GasOperation</researchPrerequisite>
     </recipeMaker>
     <tools>
       <li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
moved AK47 to GasOperation

Reasoning:
If left in Precision Rifling, there's just no reason to ever want to make one since the other options avaialable at same time are just so much better. 
Would go very well with RPD if craftable at same research, giving the player a reason to stay with them for a while. Yes, the SKS is supposedly serving the same purpose currently, but it's not very useful and honestly just bloat (same as IRL).
I don't see why it'd be preferable to force the player to rush to Precision Rifling to get any semi-capable rifle, thisway you'd still have the incentive to upgrade when you can afford it but can have something that works in the meantime.