### PR TITLE
Add VFE: Security long range bombardment to 105mm Howitzer

### DIFF
--- a/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
+++ b/Patches/Vanilla Furniture Expanded - Security/ThingDefs_Manned.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Vanilla Furniture Expanded - Security</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+		<operations>
+
+		<!-- ========== 105mm Howitzer - Long Range Artillery ========== -->
+	  
+		<li Class="PatchOperationAdd">
+			<xpath>Defs/ThingDef[defName = "CE_Artillery_Howitzer"]</xpath>
+			<value>
+				<comps>
+					<li Class="VFESecurity.CompProperties_LongRangeArtillery">
+						<worldTileRange>11</worldTileRange>
+						<maxForcedMissRadiusFactor>2.5</maxForcedMissRadiusFactor>
+						<gizmoIconTexPath>Things/Building/Artillery/TurretArtillery_Top</gizmoIconTexPath>
+					</li>
+				</comps>
+			</value>
+		</li>
+
+		</operations>
+		</match>
+	</Operation>
+</Patch>    


### PR DESCRIPTION
Works during testing.

When CE: Guns is loaded with VFE: Security, the 105mm Howitzer will be able to bombard long-range targets.