### PR TITLE
Fix FAL's range

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -514,7 +514,7 @@
         <burstShotCount>6</burstShotCount>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
         <warmupTime>1.1</warmupTime>
-        <range>62</range>
+        <range>55</range>
         <soundCast>Shot_AssaultRifle</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>

--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -514,7 +514,7 @@
         <burstShotCount>6</burstShotCount>
         <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
         <warmupTime>1.1</warmupTime>
-        <range>48</range>
+        <range>62</range>
         <soundCast>Shot_AssaultRifle</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
What it say's on the tin.

21 inch barrel FAL has an effective range of 600m, which we have the 21 inch version in CE Guns, not the 16 inch one.
I was under the impression that what we had was the 16 inch barrel version hence the low effective range of 400 meters.
It has all the stats of the 21 inch version with the effective range of the 16 inch one, this PR fixes that.

The alternative is to keep the range nerf and tweak the other stats being bulk, spread and such.