### PR TITLE
Proper magazine size for the Lever Boi

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -424,7 +424,7 @@
     </weaponTags>
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
-        <magazineSize>8</magazineSize>
+        <magazineSize>12</magazineSize>
         <reloadOneAtATime>true</reloadOneAtATime>
         <reloadTime>0.85</reloadTime>
         <ammoSet>AmmoSet_44Magnum_HV</ammoSet>


### PR DESCRIPTION
Increased the magazine size of the Winchester 94 based on the proper source.

https://www.winchesterguns.com/products/rifles/model-94/past/model-94-legacy-24.html
https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037