### PR TITLE
Switch the charge shotgun from pump-action to semi-auto

### DIFF
--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2039,7 +2039,7 @@
       <li>ShortShots</li>
     </weaponClasses>
     <statBases>
-      <WorkToMake>50000</WorkToMake>
+      <WorkToMake>39500</WorkToMake>
       <Mass>4.0</Mass>
       <Bulk>8.50</Bulk>
       <ShotSpread>0.14</ShotSpread>
@@ -2263,7 +2263,7 @@
       <li>RangedHeavy</li>
     </weaponClasses>
     <statBases>
-      <WorkToMake>51000</WorkToMake>
+      <WorkToMake>50500</WorkToMake>
       <SightsEfficiency>2.6</SightsEfficiency>
       <ShotSpread>0.03</ShotSpread>
       <SwayFactor>1.9</SwayFactor>
@@ -2273,7 +2273,7 @@
       <NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
     </statBases>
     <costList>
-      <Steel>65</Steel>
+      <Steel>60</Steel>
       <Plasteel>30</Plasteel>
       <ComponentIndustrial>10</ComponentIndustrial>
       <Chemfuel>15</Chemfuel>

--- a/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2045,7 +2045,7 @@
       <ShotSpread>0.14</ShotSpread>
       <SwayFactor>1.25</SwayFactor>
       <SightsEfficiency>1.10</SightsEfficiency>
-      <RangedWeapon_Cooldown>1.0</RangedWeapon_Cooldown>
+      <RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
     </statBases>
     <costList>
       <Steel>50</Steel>


### PR DESCRIPTION
what it says on the tin, it was supposed to be semi-auto instead of pump-action, it was set to pump-action by mistake.
The rack in its texture is intended to be a backup mechanism.

https://docs.google.com/spreadsheets/d/1lbT0zzagCRPDJG4GctkeeoTsFCt3lYfM4SRnWt8ql-k/edit#gid=1573763037