### PR TITLE
Tweak the Flintlocks' reload time and fix the Milkor's reload behavior

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -131,7 +131,7 @@
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
         <AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
-        <reloadTime>4</reloadTime>
+        <reloadTime>4.9</reloadTime>
         <ammoSet>AmmoSet_SlowMusketBall</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
@@ -231,7 +231,7 @@
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
         <AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
-        <reloadTime>4.9</reloadTime>
+        <reloadTime>6.9</reloadTime>
         <ammoSet>AmmoSet_BlunderbussShot</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">
@@ -341,7 +341,7 @@
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
         <AmmoGenPerMagOverride>4</AmmoGenPerMagOverride>
-        <reloadTime>4.9</reloadTime>
+        <reloadTime>6.9</reloadTime>
         <ammoSet>AmmoSet_FastMusketBall</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">

--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1780,7 +1780,8 @@
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>6</magazineSize>
-        <reloadTime>5.1</reloadTime>
+        <reloadOneAtATime>true</reloadOneAtATime>
+        <reloadTime>0.85</reloadTime>
         <ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
       </li>
       <li Class="CombatExtended.CompProperties_FireModes">


### PR DESCRIPTION
Increased the reload time of the flintlock weapons to a value in-between the old and new ones as the reduction of the values was a bit excessive.

Made the Milkor be reloaded one-at-a-time as it should be.