### PR TITLE
Medieval weapons' weapon tag tweaks

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -51,7 +51,7 @@
     <comps>
       <li Class="CombatExtended.CompProperties_AmmoUser">
         <magazineSize>1</magazineSize>
-        <AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
+        <AmmoGenPerMagOverride>2</AmmoGenPerMagOverride>
         <reloadTime>4</reloadTime>
         <ammoSet>AmmoSet_CrossbowBolt</ammoSet>
       </li>
@@ -122,8 +122,6 @@
     <weaponTags>
       <li>Gun</li>
       <li>SimpleGun</li>
-      <li>NeolithicRangedHeavy</li>
-      <li>NeolithicRangedChief</li>
       <li>CE_AI_BROOM</li>
       <li>CE_OneHandedWeapon</li>
     </weaponTags>
@@ -229,8 +227,6 @@
     <weaponTags>
       <li>Gun</li>
       <li>SimpleGun</li>
-      <li>NeolithicRangedHeavy</li>
-      <li>NeolithicRangedChief</li>
       <li>CE_AI_BROOM</li>
     </weaponTags>
     <comps>
@@ -345,8 +341,6 @@
     <weaponTags>
       <li>Gun</li>
       <li>SimpleGun</li>
-      <li>NeolithicRangedHeavy</li>
-      <li>NeolithicRangedChief</li>
       <li>CE_AI_AR</li>
     </weaponTags>
     <comps>

--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -89,6 +89,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Revolver</soundInteract>
+    <generateCommonality>0.33</generateCommonality>
     <weaponClasses>
       <li>RangedLight</li>
       <li>ShortShots</li>
@@ -192,6 +193,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>
+    <generateCommonality>0.33</generateCommonality>
     <weaponClasses>
       <li>ShortShots</li>
     </weaponClasses>
@@ -306,6 +308,7 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <soundInteract>Interact_Rifle</soundInteract>
+    <generateCommonality>0.33</generateCommonality>
     <weaponClasses>
       <li>LongShots</li>
     </weaponClasses>


### PR DESCRIPTION
Changed the `AmmoGenPerMagOverride` of the crossbow from 3 to 2 since it spawns on neolithic pawns and a high mag size means that they spawn with too much ammo that impedes their combat capabilities.

The flintlock weapons don't need the Neolithic weapon tags as the Heavy tag is only used by the Heavy Archer pawnKind which uses the loadout tailored for a pawn that spawns with bows and not guns, as a result they can spawn with 80+ ammo. The Chief tag is not used in vanilla anymore as it's patch replaced by CE to SimpleGun and we don't want an accidental pawn to spawn with flintlocks resulting a ton of ammo in their inventory.

Changed the flintlocks' commonality down to 0.33 to stop them spawning too frequently on pawns that leads to a nerf in firepower.