### PR TITLE
Minor tweaks to the musket

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -345,6 +345,7 @@
 		<weaponTags>
 			<li>Gun</li>
 			<li>SimpleGun</li>
+			<li>NoSwitch</li>
 			<li>CE_AI_AR</li>
 		</weaponTags>
 		<comps>
@@ -395,9 +396,9 @@
 				<capacities>
 					<li>Stab</li>
 				</capacities>
-				<power>13</power>
+				<power>12</power>
 				<cooldownTime>1.55</cooldownTime>
-				<armorPenetrationSharp>1.3</armorPenetrationSharp>
+				<armorPenetrationSharp>1.11</armorPenetrationSharp>
 				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 			</li>

--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -392,12 +392,13 @@
 				<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
 			</li>
 			<li Class="CombatExtended.ToolCE">
-				<label>muzzle</label>
+				<label>bayonet</label>
 				<capacities>
 					<li>Stab</li>
 				</capacities>
 				<power>12</power>
 				<cooldownTime>1.55</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
 				<armorPenetrationSharp>1.11</armorPenetrationSharp>
 				<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>


### PR DESCRIPTION
Adjusted and standardized the bayonet stats and gave the musket the `NoSwitch` weapon tag.

https://docs.google.com/spreadsheets/d/11e6FkTQvZiJpq7DpXUk9JSXBSq9enrx0DQhTTJ2xH7c/edit?pli=1#gid=647442519