### PR TITLE
Sight efficiency tweak

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1054,7 +1054,7 @@
 		</weaponClasses>
 		<statBases>
 			<WorkToMake>45000</WorkToMake>
-			<SightsEfficiency>3.5</SightsEfficiency>
+			<SightsEfficiency>3.2</SightsEfficiency>
 			<ShotSpread>0.03</ShotSpread>
 			<SwayFactor>2.07</SwayFactor>
 			<Bulk>12.40</Bulk>
@@ -1072,7 +1072,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_50BMG_FMJ</defaultProjectile>
-				<warmupTime>4.05</warmupTime>
+				<warmupTime>3.8</warmupTime>
 				<range>86</range>
 				<soundCast>Shot_SniperRifle</soundCast>
 				<soundCastTail>GunTail_Heavy</soundCastTail>
@@ -2481,7 +2481,7 @@
 		</weaponClasses>
 		<statBases>
 			<WorkToMake>64000</WorkToMake>
-			<SightsEfficiency>3.50</SightsEfficiency>
+			<SightsEfficiency>3.2</SightsEfficiency>
 			<ShotSpread>0.03</ShotSpread>
 			<SwayFactor>1.76</SwayFactor>
 			<Bulk>15.0</Bulk>
@@ -2501,7 +2501,7 @@
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_12x72mmCharged</defaultProjectile>
-				<warmupTime>4.05</warmupTime>
+				<warmupTime>3.8</warmupTime>
 				<range>86</range>
 				<soundCast>ChargeLance_Fire</soundCast>
 				<soundCastTail>GunTail_Medium</soundCastTail>


### PR DESCRIPTION
Reduced the sight efficiency on the AMRs by x5 which as a result reduces the warmup time by .25s.