### PR TITLE
Add tech level to charge AMR

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2475,6 +2475,7 @@
 		<defName>CE_Gun_ChargeAMR</defName>
 		<label>A-12 charge anti-materiel rifle</label>
 		<description>Charged-shot anti-materiel rifle equipped with advanced optics for long-range shooting.</description>
+		<techLevel>Spacer</techLevel>
 		<graphicData>
 			<texPath>Things/Weapons/ChargeAMR</texPath>
 			<graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
All charge weapons in CE guns have a tech level except for charge AMR. Not a big deal unless you are using a mod that adds techblocks or something like that. Still a bug that needs fixing.
