### PR TITLE
Charge pistol caliber tweak

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1900,7 +1900,7 @@
 
 	<ThingDef ParentName="BaseHumanMakeableGun">
 		<defName>CE_Gun_ChargePistol</defName>
-		<label>P-10 charge pistol</label>
+		<label>P-6 charge pistol</label>
 		<description>Charged-shot pistol, commonly used by glitterworld police forces and mercenaries as a sidearm.</description>
 		<techLevel>Spacer</techLevel>
 		<graphicData>
@@ -1913,12 +1913,12 @@
 		</weaponClasses>
 		<statBases>
 			<WorkToMake>16500</WorkToMake>
-			<Mass>1.1</Mass>
-			<Bulk>2.25</Bulk>
+			<Mass>0.9</Mass>
+			<Bulk>2.0</Bulk>
 			<ShotSpread>0.15</ShotSpread>
-			<SwayFactor>1.12</SwayFactor>
+			<SwayFactor>0.97</SwayFactor>
 			<SightsEfficiency>0.8</SightsEfficiency>
-			<RangedWeapon_Cooldown>0.39</RangedWeapon_Cooldown>
+			<RangedWeapon_Cooldown>0.38</RangedWeapon_Cooldown>
 		</statBases>
 		<costList>
 			<Steel>20</Steel>
@@ -1929,22 +1929,22 @@
 		</costList>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
-				<recoilAmount>2.96</recoilAmount>
+				<recoilAmount>2.33</recoilAmount>
 				<verbClass>CombatExtended.Verb_ShootCE</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<defaultProjectile>Bullet_10x18mmCharged</defaultProjectile>
+				<defaultProjectile>Bullet_6x18mmCharged</defaultProjectile>
 				<warmupTime>0.5</warmupTime>
 				<range>16</range>
 				<soundCast>Shot_ChargeRifle</soundCast>
-				<soundCastTail>GunTail_Medium</soundCastTail>
+				<soundCastTail>GunTail_Light</soundCastTail>
 				<muzzleFlashScale>9</muzzleFlashScale>
 			</li>
 		</verbs>
 		<comps>
 			<li Class="CombatExtended.CompProperties_AmmoUser">
-				<magazineSize>10</magazineSize>
+				<magazineSize>15</magazineSize>
 				<reloadTime>4</reloadTime>
-				<ammoSet>AmmoSet_10x18mmCharged</ammoSet>
+				<ammoSet>AmmoSet_6x18mmCharged</ammoSet>
 			</li>
 			<li Class="CombatExtended.CompProperties_FireModes">
 				<aiAimMode>Snapshot</aiAimMode>


### PR DESCRIPTION
## Changes

- Reverted back to using 6x18mm charge caliber, and increased the magazine size to 15

## Reasoning

- Basic charge pistol using 10x18mm charged was creating balancing issues with other charge sidearms, primarily revolvers due to not having a higher pistol caliber available
- This version should represent a light and high capacity standard caliber pistol to serve as a baseline.

## Alternatives

- Keep it as a magnum-like with higher weight and low magazine capacity
  - Gives less of a potential ceiling for patching charge revolvers.
