### PR TITLE
S&W Governor drawSize Fix

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -415,7 +415,7 @@
 		<graphicData>
 			<texPath>Things/Weapons/SWGovernor</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<drawSize>(0.92,1.92)</drawSize>
+			<drawSize>(0.92,0.92)</drawSize>
 		</graphicData>
 		<soundInteract>Interact_Revolver</soundInteract>
 		<weaponClasses>

--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -415,7 +415,7 @@
 		<graphicData>
 			<texPath>Things/Weapons/SWGovernor</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<drawSize>(0.92,1.92)</drawSize>
+			<drawSize>(0.92,0.92)</drawSize>
 		</graphicData>
 		<soundInteract>Interact_Revolver</soundInteract>
 		<weaponClasses>


### PR DESCRIPTION
Fix the S&W Governor looking cursed due to a horribly incorrect drawSize, presumably caused by a typo that was previously covered-up by CE's `GunDrawExtension`.