### PR TITLE
Fix Governor drawSize typo

### DIFF
--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -415,7 +415,7 @@
 		<graphicData>
 			<texPath>Things/Weapons/SWGovernor</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<drawSize>(0.92,1.92)</drawSize>
+			<drawSize>(0.92,0.92)</drawSize>
 		</graphicData>
 		<soundInteract>Interact_Revolver</soundInteract>
 		<weaponClasses>


### PR DESCRIPTION
## Changes
- Fix a typo in the S&W Governor drawSize.

## Reasoning
- Iron too big.

## Alternatives
- Continue to compensate for something.

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
