### PR TITLE
Sidearm-only charge pistol

### DIFF
--- a/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.4/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -1943,7 +1943,6 @@
 		</comps>
 		<weaponTags>
 			<li>AdvancedGun</li>
-			<li>SpacerGun</li>
 			<li>CE_Sidearm</li>
 			<li>CE_SpacerSidearm</li>
 			<li>CE_OneHandedWeapon</li>

--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2155,7 +2155,6 @@
 		</comps>
 		<weaponTags>
 			<li>AdvancedGun</li>
-			<li>SpacerGun</li>
 			<li>CE_Sidearm</li>
 			<li>CE_SpacerSidearm</li>
 			<li>CE_OneHandedWeapon</li>


### PR DESCRIPTION
## Changes

- Made sure the charge pistol does not spawn as a main weapon, only as a sidearm.

## Reasoning

- With how anemic the weapon has become, it shouldn't spawn as a primary weapon on NPCs no matter what.