### PR TITLE
Tweak RM2 Warmup

### DIFF
--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2840,7 +2840,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Bullet_Flamethrower_Prometheum</defaultProjectile>
 				<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
-				<warmupTime>1.1</warmupTime>
+				<warmupTime>0.6</warmupTime>
 				<range>11</range>
 				<minRange>3</minRange>
 				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>


### PR DESCRIPTION
## Changes

- Change the RM2's warmup time to that of SMG/shotgun type weapons.


## Reasoning
- Flamethrowers in CE are close-ranged spray and pray weapons, similar to a shotgun or SMG, yet they use the warm up times of full-sized rifles. This caused many situations where pawns won't fire until the target is basically inside the minimum firing range circle and getting dangerously close to the shooter.

## Alternatives
- "Hold still while I aim this flamethrower"

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] Playtested a colony (specify how long)
