### PR TITLE
WeaponTag Inheritance Fixes

### DIFF
--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2231,6 +2231,7 @@
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<weaponTags Inherit="False">
+			<li>GunGrenadeLauncher</li>
 			<li>GunHeavy</li>
 			<li>CE_AI_AOE</li>
 		</weaponTags>
@@ -3035,8 +3036,7 @@
 			<Chemfuel>10</Chemfuel>
 		</costList>
 		<weaponTags Inherit="False">
-			<li>GunHeavy</li>
-			<li>CE_AI_AOE</li>
+			<li>Flamethrower</li>
 		</weaponTags>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">

--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -3037,6 +3037,7 @@
 		</costList>
 		<weaponTags Inherit="False">
 			<li>Flamethrower</li>
+			<li>CE_AI_AOE</li>
 		</weaponTags>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">

--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -2145,7 +2145,7 @@
 			<ComponentIndustrial>4</ComponentIndustrial>
 			<WoodLog>5</WoodLog>
 		</costList>
-		<weaponTags>
+		<weaponTags Inherit="False">
 			<li>GunHeavy</li>
 			<li>CE_AI_AOE</li>
 		</weaponTags>
@@ -2230,7 +2230,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 			<Chemfuel>10</Chemfuel>
 		</costList>
-		<weaponTags>
+		<weaponTags Inherit="False">
 			<li>GunHeavy</li>
 			<li>CE_AI_AOE</li>
 		</weaponTags>
@@ -3034,7 +3034,7 @@
 			<ComponentIndustrial>3</ComponentIndustrial>
 			<Chemfuel>10</Chemfuel>
 		</costList>
-		<weaponTags>
+		<weaponTags Inherit="False">
 			<li>GunHeavy</li>
 			<li>CE_AI_AOE</li>
 		</weaponTags>


### PR DESCRIPTION
## Changes
- Added `Inherit ="False"` to various weapons tagged as "GunHeavy", such as the RPG-7, Milkor MGL, and RM2.

## Reasoning
- For the longest time these guns were set to spawn on Mercenary Heavies, but since they also inherit the generic gun tag they could also spawn on any low-tier industrial pawnKinds. This simply changes the way these weapons spawn to be more consistent with what's set for similar vanilla guns such as the rocket launchers from vanilla, or base CE's M79 & M72 LAW.
- In the case of the RM2 specifically, the "flamethrower" tag is used by the Anomaly Incinerator, which Mercenary Heavies are also set to spawn with.

We may also wanna consider adding the PTRS to the GunHeavy spawning pool, since it is in fact a very heavy gun.