### PR TITLE
Give flamethrower a muzzle flash rating

### DIFF
--- a/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.5/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -3052,7 +3052,7 @@
 				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 				<burstShotCount>20</burstShotCount>
 				<soundCast>HissFlamethrower</soundCast>
-				<muzzleFlashScale>0</muzzleFlashScale>
+				<muzzleFlashScale>20</muzzleFlashScale>
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>

--- a/1.6/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -3051,7 +3051,7 @@
 				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 				<burstShotCount>20</burstShotCount>
 				<soundCast>HissFlamethrower</soundCast>
-				<muzzleFlashScale>0</muzzleFlashScale>
+				<muzzleFlashScale>20</muzzleFlashScale>
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>


### PR DESCRIPTION
### Changes

* Gives flamethrower muzzle flash scale of 20, instead of 0.

### Reasoning

* Flamethrower users irl are very easy to see. It doesn't take long to figure out where the stream of flame is coming from, even if they are obscured by it.
* Makes flamethrower a little more dangerous to use at night.
* 20 is same as all big guns, but doesn't make the visual fleck gigantic. 99 size for fleck occupies like 30 tiles in diameter.

### Alternatives
* Give it a bigger value or longer lasting muzzle flash somehow.

### Testing

Check tests you have performed:

- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)