### PR TITLE
Add warmup mote and sound to flamethrower

### DIFF
--- a/1.6/Defs/ThingDefs/Weapons_CE_Guns.xml
+++ b/1.6/Defs/ThingDefs/Weapons_CE_Guns.xml
@@ -3055,6 +3055,9 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
+				<aimingChargeMote>CE_Mote_Flamethrower_Warmup</aimingChargeMote>
+        		<aimingChargeMoteOffset>0.95</aimingChargeMoteOffset>
+				<soundAiming>Flamethrower_Firing</soundAiming>
 			</li>
 		</verbs>
 		<comps>


### PR DESCRIPTION
## Additions

Describe new functionality added by your code, e.g.
- Adds a mote to flamethrower warmup
- Reuses Core's flamethrower sound for our flamer aiming sustainer.

## References

Links to the associated issues or other related pull requests, e.g.
- Requires https://github.com/CombatExtended-Continued/CombatExtended/pull/4445

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (specify how long)
